### PR TITLE
whyred: rootdir: fix MTP device name

### DIFF
--- a/rootdir/bin/init.qcom.usb.sh
+++ b/rootdir/bin/init.qcom.usb.sh
@@ -96,12 +96,15 @@ esac
 
 # check configfs is mounted or not
 if [ -d /config/usb_gadget ]; then
-	# Chip-serial is used for unique MSM identification in Product string
-	msm_serial=`cat /sys/devices/soc0/serial_number`;
-	msm_serial_hex=`printf %08X $msm_serial`
-	machine_type=`cat /sys/devices/soc0/machine`
-	product_string="$machine_type-$soc_hwplatform _SN:$msm_serial_hex"
-	echo "$product_string" > /config/usb_gadget/g1/strings/0x409/product
+	product_string=`cat /config/usb_gadget/g1/strings/0x409/product` 2> /dev/null
+	if [ "product_string" == "" ]; then
+		# Chip-serial is used for unique MSM identification in Product string
+		msm_serial=`cat /sys/devices/soc0/serial_number`;
+		msm_serial_hex=`printf %08X $msm_serial`
+		machine_type=`cat /sys/devices/soc0/machine`
+		product_string="$machine_type-$soc_hwplatform _SN:$msm_serial_hex"
+		echo "$product_string" > /config/usb_gadget/g1/strings/0x409/product
+	fi
 
 	# ADB requires valid iSerialNumber; if ro.serialno is missing, use dummy
 	serialnumber=`cat /config/usb_gadget/g1/strings/0x409/serialnumber` 2> /dev/null


### PR DESCRIPTION
use ro.product.model as mtp device name instead of "$machine_type-$soc_hwplatform _SN:$msm_serial_hex" directly